### PR TITLE
Removed explicit ext-SimpleXML dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "ext-SimpleXML": "^7.3",
+    "ext-SimpleXML": "*",
     "php": ">=5.4.0",
     "ext-curl": "*",
     "ext-json": "*",

--- a/src/BandwidthClient.php
+++ b/src/BandwidthClient.php
@@ -25,7 +25,7 @@ class BandwidthClient
 
     /**
      * Provides access to Messaging client
-     * @return Messaging\Messaging
+     * @return Messaging\MessagingClient
      */
     public function getMessaging()
     {
@@ -37,7 +37,7 @@ class BandwidthClient
 
     /**
      * Provides access to Voice client
-     * @return Voice\Voice
+     * @return Voice\VoiceClient
      */
     public function getVoice()
     {


### PR DESCRIPTION
This resolves an issue with PHP versions that are less than 7.3