### PR TITLE
Removed explicit ext-SimpleXML dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "ext-SimpleXML": "^7.3",
+    "ext-SimpleXML": "*",
     "php": ">=5.4.0",
     "ext-curl": "*",
     "ext-json": "*",


### PR DESCRIPTION
This resolves an issue with PHP versions less than 7.3

(previous PR removed as it wasn't in a separate branch)