### PR TITLE
Fixed double-encoding of attributes, and encoded element contents.

### DIFF
--- a/src/Voice/Bxml/Bridge.php
+++ b/src/Voice/Bxml/Bridge.php
@@ -140,7 +140,9 @@ class Bridge extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("Bridge", $this->targetCall);
+        $element = $doc->createElement("Bridge");
+
+        $element->appendChild($doc->createTextNode($this->targetCall));
 
         if(isset($this->bridgeCompleteUrl)) {
             $element->setAttribute("bridgeCompleteUrl", $this->bridgeCompleteUrl);

--- a/src/Voice/Bxml/Conference.php
+++ b/src/Voice/Bxml/Conference.php
@@ -140,7 +140,9 @@ class Conference extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("Conference", $this->conferenceName);
+        $element = $doc->createElement("Conference");
+
+        $element->appendChild($doc->createTextNode($this->conferenceName));
 
         if(isset($this->username)) {
             $element->setattribute("username", $this->username);

--- a/src/Voice/Bxml/PhoneNumber.php
+++ b/src/Voice/Bxml/PhoneNumber.php
@@ -122,7 +122,9 @@ class PhoneNumber extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("PhoneNumber", $this->phoneNumber);
+        $element = $doc->createElement("PhoneNumber");
+
+        $element->appendChild($doc->createTextNode($this->phoneNumber));
 
         if(isset($this->username)) {
             $element->setAttribute("username", $this->username);

--- a/src/Voice/Bxml/PlayAudio.php
+++ b/src/Voice/Bxml/PlayAudio.php
@@ -41,7 +41,9 @@ class PlayAudio extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("PlayAudio", $this->url);
+        $element = $doc->createElement("PlayAudio");
+
+        $element->appendChild($doc->createTextNode($this->url));
 
         if(isset($this->username)) {
             $element->setAttribute("username", $this->username);

--- a/src/Voice/Bxml/Response.php
+++ b/src/Voice/Bxml/Response.php
@@ -26,11 +26,6 @@ class Response {
      * @param Verb $verb The verb to add to the list
      */
     public function addVerb($verb) {
-        foreach($verb as $key => $value) {  // encodes any verb attributes of type string to avoid php character encoding bug
-            if(gettype($value) == "string") {
-                $verb->$key = htmlspecialchars($value, ENT_XML1, 'UTF-8');
-            }
-        }
         array_push($this->verbs, $verb);
     }
 

--- a/src/Voice/Bxml/SendDtmf.php
+++ b/src/Voice/Bxml/SendDtmf.php
@@ -41,7 +41,9 @@ class SendDtmf extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("SendDtmf", $this->digits);
+        $element = $doc->createElement("SendDtmf");
+
+        $element->appendChild($doc->createTextNode($this->digits));
 
         if(isset($this->toneDuration)) {
             $element->setattribute("toneDuration", $this->toneDuration);

--- a/src/Voice/Bxml/SipUri.php
+++ b/src/Voice/Bxml/SipUri.php
@@ -131,7 +131,9 @@ class SipUri extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("SipUri", $this->sip);
+        $element = $doc->createElement("SipUri");
+
+        $element->appendChild($doc->createTextNode($this->sip));
 
         if(isset($this->username)) {
             $element->setAttribute("username", $this->username);

--- a/src/Voice/Bxml/SpeakSentence.php
+++ b/src/Voice/Bxml/SpeakSentence.php
@@ -50,7 +50,9 @@ class SpeakSentence extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("SpeakSentence", $this->sentence);
+        $element = $doc->createElement("SpeakSentence");
+
+        $element->appendChild($doc->createTextNode($this->sentence));
 
         if(isset($this->locale)) {
             $element->setAttribute("locale", $this->locale);

--- a/src/Voice/Bxml/Tag.php
+++ b/src/Voice/Bxml/Tag.php
@@ -23,7 +23,9 @@ class Tag extends Verb {
     }
 
     public function toBxml($doc) {
-        $element = $doc->createElement("Tag", $this->tag);
+        $element = $doc->createElement("Tag");
+
+        $element->appendChild($doc->createTextNode($this->tag));
 
         return $element;
     }


### PR DESCRIPTION
Example code:

```php
$gather = new Gather;
$gather->gatherUrl = 'https://example.com/bandwidth-call?test1=test1&test2=test2';
$bxml->addVerb($gather);
```

Expected XML output:

```xml
<Gather gatherUrl="https://example.com/bandwidth-call?test1=test1&amp;test2=test2"/>
```

Actual output:
```xml
<Gather gatherUrl="https://example.com/bandwidth-call?test1=test1&amp;amp;test2=test2"/>
```

Note that the ampersand (`&`) is double-encoded in the `gatherUrl` attribute.

This was introduced in #43. It appears the intent was to encode a DOM element's _contents_. But it also encodes all _attributes_.

There is no need to encode the attributes. See [this example](https://phponlines.com/result/nq3AMRqK30); attributes are encoded automatically.

See [this comment](https://www.php.net/manual/en/domdocument.createelement.php#73617) about using htmlentities with [DOMDocument::createElement](https://www.php.net/manual/en/domdocument.createelement.php). If what is needed is to encode the element's contents (for example, the SpeakSentence contents), then we should either encode the inner element contents, or use [DOMDocument::createTextNode](https://www.php.net/manual/en/domdocument.createtextnode.php).

See [this example](https://phponlines.com/result/EVml68nv5P); using createTextNode automatically an element's contents.

This pull request removes the code added in #43 and replaces it with code to use `createTextNode()` to encode the inner contents of verbs which need it.