### PR TITLE
Return static instead of type of class

### DIFF
--- a/src/Voice/Bxml/Bridge.php
+++ b/src/Voice/Bxml/Bridge.php
@@ -86,7 +86,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeCompleteUrl URL to send the bridge complete event to
      */
-    public function bridgeCompleteUrl(string $bridgeCompleteUrl): Bridge {
+    public function bridgeCompleteUrl(string $bridgeCompleteUrl): static {
         $this->bridgeCompleteUrl = $bridgeCompleteUrl;
         return $this;
     }
@@ -96,7 +96,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeCompleteMethod HTTP method to send the bridge complete event
      */
-    public function bridgeCompleteMethod(string $bridgeCompleteMethod): Bridge {
+    public function bridgeCompleteMethod(string $bridgeCompleteMethod): static {
         $this->bridgeCompleteMethod = $bridgeCompleteMethod;
         return $this;
     }
@@ -106,7 +106,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeTargetCompleteUrl URL to send the bridge target complete event to
      */
-    public function bridgeTargetCompleteUrl(string $bridgeTargetCompleteUrl): Bridge {
+    public function bridgeTargetCompleteUrl(string $bridgeTargetCompleteUrl): static {
         $this->bridgeTargetCompleteUrl = $bridgeTargetCompleteUrl;
         return $this;
     }
@@ -116,7 +116,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeTargetCompleteMethod HTTP method to send the bridge target complete event
      */
-    public function bridgeTargetCompleteMethod(string $bridgeTargetCompleteMethod): Bridge {
+    public function bridgeTargetCompleteMethod(string $bridgeTargetCompleteMethod): static {
         $this->bridgeTargetCompleteMethod = $bridgeTargetCompleteMethod;
         return $this;
     }
@@ -126,7 +126,7 @@ class Bridge extends Verb {
      *
      * @param string $username HTTP basic auth username for sending events
      */
-    public function username(string $username): Bridge {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -136,7 +136,7 @@ class Bridge extends Verb {
      *
      * @param string $password HTTP basic auth password for sending events
      */
-    public function password(string $password): Bridge {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -146,7 +146,7 @@ class Bridge extends Verb {
      *
      * @param string $tag String to include in events
      */
-    public function tag(string $tag): Bridge {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -156,7 +156,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeCompleteFallbackUrl Fallback URL for bridge complete callback events
      */
-    public function bridgeCompleteFallbackUrl(string $bridgeCompleteFallbackUrl): Bridge {
+    public function bridgeCompleteFallbackUrl(string $bridgeCompleteFallbackUrl): static {
         $this->bridgeCompleteFallbackUrl = $bridgeCompleteFallbackUrl;
         return $this;
     }
@@ -166,7 +166,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeCompleteFallbackMethod HTTP method for bridge complete fallback requests 
      */
-    public function bridgeCompleteFallbackMethod(string $bridgeCompleteFallbackMethod): Bridge {
+    public function bridgeCompleteFallbackMethod(string $bridgeCompleteFallbackMethod): static {
         $this->bridgeCompleteFallbackMethod = $bridgeCompleteFallbackMethod;
         return $this;
     }
@@ -176,7 +176,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeTargetCompleteFallbackUrl Fallback URL for bridge target complete callback events 
      */
-    public function bridgeTargetCompleteFallbackUrl(string $bridgeTargetCompleteFallbackUrl): Bridge {
+    public function bridgeTargetCompleteFallbackUrl(string $bridgeTargetCompleteFallbackUrl): static {
         $this->bridgeTargetCompleteFallbackUrl = $bridgeTargetCompleteFallbackUrl;
         return $this;
     }
@@ -186,7 +186,7 @@ class Bridge extends Verb {
      *
      * @param string $bridgeTargetCompleteFallbackMethod HTTP method for bridge target complete fallback events 
      */
-    public function bridgeTargetCompleteFallbackMethod(string $bridgeTargetCompleteFallbackMethod): Bridge {
+    public function bridgeTargetCompleteFallbackMethod(string $bridgeTargetCompleteFallbackMethod): static {
         $this->bridgeTargetCompleteFallbackMethod = $bridgeTargetCompleteFallbackMethod;
         return $this;
     }
@@ -196,7 +196,7 @@ class Bridge extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events
      */
-    public function fallbackUsername(string $fallbackUsername): Bridge {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -206,7 +206,7 @@ class Bridge extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password 
      */
-    public function fallbackPassword(string $fallbackPassword): Bridge {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/Bxml.php
+++ b/src/Voice/Bxml/Bxml.php
@@ -29,7 +29,7 @@ class Bxml {
      *
      * @param Verb $verb The verb to add to the list
      */
-    public function addVerb(Verb $verb): Bxml {
+    public function addVerb(Verb $verb): static {
         array_push($this->verbs, $verb);
         return $this;
     }

--- a/src/Voice/Bxml/Conference.php
+++ b/src/Voice/Bxml/Conference.php
@@ -82,7 +82,7 @@ class Conference extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): Conference {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -92,7 +92,7 @@ class Conference extends Verb {
      *
      * @param string $username Username for basic auth for callbacks
      */
-    public function username(string $username): Conference {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -102,7 +102,7 @@ class Conference extends Verb {
      *
      * @param string $password Password for basic auth for callbacks
      */
-    public function password(string $password): Conference {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -112,7 +112,7 @@ class Conference extends Verb {
      *
      * @param string $conferenceEventUrl URL to receive conference events 
      */
-    public function conferenceEventUrl(string $conferenceEventUrl): Conference {
+    public function conferenceEventUrl(string $conferenceEventUrl): static {
         $this->conferenceEventUrl = $conferenceEventUrl;
         return $this;
     }
@@ -122,7 +122,7 @@ class Conference extends Verb {
      *
      * @param string $conferenceEventMethod HTTP method for conference events 
      */
-    public function conferenceEventMethod(string $conferenceEventMethod): Conference {
+    public function conferenceEventMethod(string $conferenceEventMethod): static {
         $this->conferenceEventMethod = $conferenceEventMethod;
         return $this;
     }
@@ -132,7 +132,7 @@ class Conference extends Verb {
      *
      * @param string $callIdsToCoach A string of comma separated call IDs to coach 
      */
-    public function callIdsToCoach(string $callIdsToCoach): Conference {
+    public function callIdsToCoach(string $callIdsToCoach): static {
         $this->callIdsToCoach = $callIdsToCoach;
         return $this;
     }
@@ -142,7 +142,7 @@ class Conference extends Verb {
      *
      * @param array $callIdsToCoach An array of call IDs to coach 
      */
-    public function callIdsToCoachArray(array $callIdsToCoach): Conference {
+    public function callIdsToCoachArray(array $callIdsToCoach): static {
         $this->callIdsToCoach = implode(",", $callIdsToCoach);
         return $this;
     }
@@ -152,7 +152,7 @@ class Conference extends Verb {
      *
      * @param boolean $mute Determines if conference members should be on mute
      */
-    public function mute(bool $mute): Conference {
+    public function mute(bool $mute): static {
         $this->mute = $mute;
         return $this;
     }
@@ -162,7 +162,7 @@ class Conference extends Verb {
      *
      * @param boolean $hold Determines if conference members should be on hold
      */
-    public function hold(bool $hold): Conference {
+    public function hold(bool $hold): static {
         $this->hold = $hold;
         return $this;
     }
@@ -172,7 +172,7 @@ class Conference extends Verb {
      *
      * @param string $conferenceEventFallbackUrl Fallback url for conference events
      */
-    public function conferenceEventFallbackUrl(string $conferenceEventFallbackUrl): Conference {
+    public function conferenceEventFallbackUrl(string $conferenceEventFallbackUrl): static {
         $this->conferenceEventFallbackUrl = $conferenceEventFallbackUrl;
         return $this;
     }
@@ -182,7 +182,7 @@ class Conference extends Verb {
      *
      * @param string $conferenceEventFallbackMethod HTTP method for fallback events 
      */
-    public function conferenceEventFallbackMethod(string $conferenceEventFallbackMethod): Conference {
+    public function conferenceEventFallbackMethod(string $conferenceEventFallbackMethod): static {
         $this->conferenceEventFallbackMethod = $conferenceEventFallbackMethod;
         return $this;
     }
@@ -192,7 +192,7 @@ class Conference extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events
      */
-    public function fallbackUsername(string $fallbackUsername): Conference {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -202,7 +202,7 @@ class Conference extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events
      */
-    public function fallbackPassword(string $fallbackPassword): Conference {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/CustomParam.php
+++ b/src/Voice/Bxml/CustomParam.php
@@ -29,7 +29,7 @@ class CustomParam extends Verb {
      *
      * @param string $name (required) The name of this parameter, up to 256 characters.
      */
-    public function name(string $name): CustomParam {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }
@@ -39,7 +39,7 @@ class CustomParam extends Verb {
      *
      * @param string $value (required) The value of this parameter, up to 2048 characters.
      */
-    public function value(string $value): CustomParam {
+    public function value(string $value): static {
         $this->value = $value;
         return $this;
     }

--- a/src/Voice/Bxml/Forward.php
+++ b/src/Voice/Bxml/Forward.php
@@ -41,7 +41,7 @@ class Forward extends Verb {
      *
      * @param string $to The phone number to receive the phone call 
      */
-    public function to(string $to): Forward {
+    public function to(string $to): static {
         $this->to = $to;
         return $this;
     }
@@ -51,7 +51,7 @@ class Forward extends Verb {
      *
      * @param string $from The phone number to make the phone call
      */
-    public function from(string $from): Forward {
+    public function from(string $from): static {
         $this->from = $from;
         return $this;
     }
@@ -61,7 +61,7 @@ class Forward extends Verb {
      *
      * @param string $callTimeout The timeout in seconds for the phone call 
      */
-    public function callTimeout(string $callTimeout): Forward {
+    public function callTimeout(string $callTimeout): static {
         $this->callTimeout = $callTimeout;
         return $this;
     }
@@ -71,7 +71,7 @@ class Forward extends Verb {
      *
      * @param string $diversionTreatment The diversion treatment for the phone call 
      */
-    public function diversionTreatment(string $diversionTreatment): Forward {
+    public function diversionTreatment(string $diversionTreatment): static {
         $this->diversionTreatment = $diversionTreatment;
         return $this;
     }
@@ -81,7 +81,7 @@ class Forward extends Verb {
      *
      * @param string $diversionReason The diversion treatment for the phone call 
      */
-    public function diversionReason(string $diversionReason): Forward {
+    public function diversionReason(string $diversionReason): static {
         $this->diversionReason = $diversionReason;
         return $this;
     }

--- a/src/Voice/Bxml/Gather.php
+++ b/src/Voice/Bxml/Gather.php
@@ -91,7 +91,7 @@ class Gather extends Verb {
      *
      * @param string $username The username for http authentication for the gather callback
      */
-    public function username(string $username): Gather {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -101,7 +101,7 @@ class Gather extends Verb {
      *
      * @param string $password The password for http authentication for the gather callback
      */
-    public function password(string $password): Gather {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -111,7 +111,7 @@ class Gather extends Verb {
      *
      * @param string $gatherUrl The url to receive the gather callback 
      */
-    public function gatherUrl(string $gatherUrl): Gather {
+    public function gatherUrl(string $gatherUrl): static {
         $this->gatherUrl = $gatherUrl;
         return $this;
     }
@@ -121,7 +121,7 @@ class Gather extends Verb {
      *
      * @param string $gatherMethod The http method to send the gather callback 
      */
-    public function gatherMethod(string $gatherMethod): Gather {
+    public function gatherMethod(string $gatherMethod): static {
         $this->gatherMethod = $gatherMethod;
         return $this;
     }
@@ -131,7 +131,7 @@ class Gather extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): Gather {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -141,7 +141,7 @@ class Gather extends Verb {
      *
      * @param string $terminatingDigits Digits to terminate the gather
      */
-    public function terminatingDigits(string $terminatingDigits): Gather {
+    public function terminatingDigits(string $terminatingDigits): static {
         $this->terminatingDigits = $terminatingDigits;
         return $this;
     }
@@ -151,7 +151,7 @@ class Gather extends Verb {
      *
      * @param int $maxDigits The maximum number of digits to collect in the gather
      */
-    public function maxDigits(int $maxDigits): Gather {
+    public function maxDigits(int $maxDigits): static {
         $this->maxDigits = $maxDigits;
         return $this;
     }
@@ -161,7 +161,7 @@ class Gather extends Verb {
      *
      * @param int $interDigitTimeout The time in secods between digit presses before timing out
      */
-    public function interDigitTimeout(int $interDigitTimeout): Gather {
+    public function interDigitTimeout(int $interDigitTimeout): static {
         $this->interDigitTimeout = $interDigitTimeout;
         return $this;
     }
@@ -171,7 +171,7 @@ class Gather extends Verb {
      *
      * @param int $firstDigitTimeout The time in seconds before the first digit is pressed before timing out
      */
-    public function firstDigitTimeout(int $firstDigitTimeout): Gather {
+    public function firstDigitTimeout(int $firstDigitTimeout): static {
         $this->firstDigitTimeout = $firstDigitTimeout;
         return $this;
     }
@@ -181,7 +181,7 @@ class Gather extends Verb {
      *
      * @param PlayAudio $playAudio The PlayAudio tag to include in the Gather
      */
-    public function playAudio(PlayAudio $playAudio): Gather {
+    public function playAudio(PlayAudio $playAudio): static {
         $this->playAudio = $playAudio;
         return $this->addNestableVerb($playAudio);
     }
@@ -191,7 +191,7 @@ class Gather extends Verb {
      *
      * @param int $repeatCount The number of times to repeat the played audio
      */
-    public function repeatCount(int $repeatCount): Gather {
+    public function repeatCount(int $repeatCount): static {
         $this->repeatCount = $repeatCount;
         return $this;
     }
@@ -201,7 +201,7 @@ class Gather extends Verb {
      *
      * @param SpeakSentence $speakSentence The SpeakSentence tag to include in the Gather
      */
-    public function speakSentence(SpeakSentence $speakSentence): Gather {
+    public function speakSentence(SpeakSentence $speakSentence): static {
         $this->speakSentence = $speakSentence;
         return $this->addNestableVerb($speakSentence);
     }
@@ -211,7 +211,7 @@ class Gather extends Verb {
      *
      * @param string $gatherFallbackUrl Fallback url for gather events
      */
-    public function gatherFallbackUrl(string $gatherFallbackUrl): Gather {
+    public function gatherFallbackUrl(string $gatherFallbackUrl): static {
         $this->gatherFallbackUrl = $gatherFallbackUrl;
         return $this;
     }
@@ -221,7 +221,7 @@ class Gather extends Verb {
      *
      * @param string $gatherFallbackMethod HTTP method for fallback events
      */
-    public function gatherFallbackMethod(string $gatherFallbackMethod): Gather {
+    public function gatherFallbackMethod(string $gatherFallbackMethod): static {
         $this->gatherFallbackMethod = $gatherFallbackMethod;
         return $this;
     }
@@ -231,7 +231,7 @@ class Gather extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events
      */
-    public function fallbackUsername(string $fallbackUsername): Gather {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -241,7 +241,7 @@ class Gather extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events
      */
-    public function fallbackPassword(string $fallbackPassword): Gather {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }
@@ -251,7 +251,7 @@ class Gather extends Verb {
      *
      * @param SpeakSentence|PlayAudio $verb The nestable verb to add
      */
-    private function addNestableVerb($verb): Gather {
+    private function addNestableVerb($verb): static {
         if(!isset($this->nestableVerbs)) {
             $this->nestableVerbs = [];
         }

--- a/src/Voice/Bxml/Pause.php
+++ b/src/Voice/Bxml/Pause.php
@@ -25,7 +25,7 @@ class Pause extends Verb {
      *
      * @param float $duration The duration in seconds for the pause 
      */
-    public function duration(float $duration): Pause {
+    public function duration(float $duration): static {
         $this->duration = $duration;
         return $this;
     }

--- a/src/Voice/Bxml/PhoneNumber.php
+++ b/src/Voice/Bxml/PhoneNumber.php
@@ -78,7 +78,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $username The username for http authentication on the audio url
      */
-    public function username(string $username): PhoneNumber {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -88,7 +88,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $password The password for http authentication on the audio url
      */
-    public function password(string $password): PhoneNumber {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -98,7 +98,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferAnswerUrl The url to receive the transfer answered callback 
      */
-    public function transferAnswerUrl(string $transferAnswerUrl): PhoneNumber {
+    public function transferAnswerUrl(string $transferAnswerUrl): static {
         $this->transferAnswerUrl = $transferAnswerUrl;
         return $this;
     }
@@ -108,7 +108,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferAnswerMethod The http method to send the transfer answered callback 
      */
-    public function transferAnswerMethod(string $transferAnswerMethod): PhoneNumber {
+    public function transferAnswerMethod(string $transferAnswerMethod): static {
         $this->transferAnswerMethod = $transferAnswerMethod;
         return $this;
     }
@@ -118,7 +118,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferDisconnectUrl The url to receive the transfer disconnect callback 
      */
-    public function transferDisconnectUrl(string $transferDisconnectUrl): PhoneNumber {
+    public function transferDisconnectUrl(string $transferDisconnectUrl): static {
         $this->transferDisconnectUrl = $transferDisconnectUrl;
         return $this;
     }
@@ -128,7 +128,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferDisconnectMethod The http method to send the transfer disconnect callback 
      */
-    public function transferDisconnectMethod(string $transferDisconnectMethod): PhoneNumber {
+    public function transferDisconnectMethod(string $transferDisconnectMethod): static {
         $this->transferDisconnectMethod = $transferDisconnectMethod;
         return $this;
     }
@@ -138,7 +138,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): PhoneNumber {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -148,7 +148,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferAnswerFallbackUrl Fallback URL for transfer answer events 
      */
-    public function transferAnswerFallbackUrl(string $transferAnswerFallbackUrl): PhoneNumber {
+    public function transferAnswerFallbackUrl(string $transferAnswerFallbackUrl): static {
         $this->transferAnswerFallbackUrl = $transferAnswerFallbackUrl;
         return $this;
     }
@@ -158,7 +158,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $transferAnswerFallbackMethod HTTP method for fallback events 
      */
-    public function transferAnswerFallbackMethod(string $transferAnswerFallbackMethod): PhoneNumber {
+    public function transferAnswerFallbackMethod(string $transferAnswerFallbackMethod): static {
         $this->transferAnswerFallbackMethod = $transferAnswerFallbackMethod;
         return $this;
     }
@@ -168,7 +168,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events 
      */
-    public function fallbackUsername(string $fallbackUsername): PhoneNumber {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -178,7 +178,7 @@ class PhoneNumber extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events
      */
-    public function fallbackPassword(string $fallbackPassword): PhoneNumber {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/PlayAudio.php
+++ b/src/Voice/Bxml/PlayAudio.php
@@ -42,7 +42,7 @@ class PlayAudio extends Verb {
      *
      * @param string $username The username for http authentication on the audio url
      */
-    public function username(string $username): PlayAudio {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -52,7 +52,7 @@ class PlayAudio extends Verb {
      *
      * @param string $password The password for http authentication on the audio url
      */
-    public function password(string $password): PlayAudio {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }

--- a/src/Voice/Bxml/Record.php
+++ b/src/Voice/Bxml/Record.php
@@ -97,7 +97,7 @@ class Record extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks
      */
-    public function tag(string $tag): Record {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -107,7 +107,7 @@ class Record extends Verb {
      *
      * @param string $recordCompleteUrl URL to send the record complete callback to
      */
-    public function recordCompleteUrl(string $recordCompleteUrl): Record {
+    public function recordCompleteUrl(string $recordCompleteUrl): static {
         $this->recordCompleteUrl = $recordCompleteUrl;
         return $this;
     }
@@ -118,7 +118,7 @@ class Record extends Verb {
      * @param string $recordCompleteMethod HTTP method to send record complete
      * as ("GET" or "POST")
      */
-    public function recordCompleteMethod(string $recordCompleteMethod): Record {
+    public function recordCompleteMethod(string $recordCompleteMethod): static {
         $this->recordCompleteMethod = $recordCompleteMethod;
         return $this;
     }
@@ -128,7 +128,7 @@ class Record extends Verb {
      *
      * @param string $recordingAvailableUrl URL to send the record available callback to
      */
-    public function recordingAvailableUrl(string $recordingAvailableUrl): Record {
+    public function recordingAvailableUrl(string $recordingAvailableUrl): static {
         $this->recordingAvailableUrl = $recordingAvailableUrl;
         return $this;
     }
@@ -139,7 +139,7 @@ class Record extends Verb {
      * @param string $recordingAvailableMethod HTTP method to send record available
      * as ("GET" or "POST")
      */
-    public function recordingAvailableMethod(string $recordingAvailableMethod): Record {
+    public function recordingAvailableMethod(string $recordingAvailableMethod): static {
         $this->recordingAvailableMethod = $recordingAvailableMethod;
         return $this;
     }
@@ -149,7 +149,7 @@ class Record extends Verb {
      *
      * @param string $username Username for basic auth for callbacks
      */
-    public function username(string $username): Record {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -159,7 +159,7 @@ class Record extends Verb {
      *
      * @param string $password Password for basic auth for callbacks
      */
-    public function password(string $password): Record {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -169,7 +169,7 @@ class Record extends Verb {
      *
      * @param string $terminatingDigits Digits to terminate the recording
      */
-    public function terminatingDigits(string $terminatingDigits): Record {
+    public function terminatingDigits(string $terminatingDigits): static {
         $this->terminatingDigits = $terminatingDigits;
         return $this;
     }
@@ -179,7 +179,7 @@ class Record extends Verb {
      *
      * @param int $maxDuration Maximum length of the recording in secods
      */
-    public function maxDuration(int $maxDuration): Record {
+    public function maxDuration(int $maxDuration): static {
         $this->maxDuration = $maxDuration;
         return $this;
     }
@@ -189,7 +189,7 @@ class Record extends Verb {
      *
      * @param string $fileFormat Audio format of the recording ("mp3" or "wav")
      */
-    public function fileFormat(string $fileFormat): Record {
+    public function fileFormat(string $fileFormat): static {
         $this->fileFormat = $fileFormat;
         return $this;
     }
@@ -199,7 +199,7 @@ class Record extends Verb {
      *
      * @param boolean $detectLanguage Indicates that the recording may not be in English, and the transcription service will need to detect the dominant language the recording is in and transcribe accordingly. Current supported languages are English, French, and Spanish.
      */
-    public function detectLanguage($detectLanguage): Record {
+    public function detectLanguage($detectLanguage): static {
         $this->detectLanguage = $detectLanguage;
         return $this;
     }
@@ -209,7 +209,7 @@ class Record extends Verb {
      *
      * @param boolean $transcribe True to submit the recording for transcription, false otherwise
      */
-    public function transcribe(bool $transcribe): Record {
+    public function transcribe(bool $transcribe): static {
         $this->transcribe = $transcribe;
         return $this;
     }
@@ -219,7 +219,7 @@ class Record extends Verb {
      *
      * @param string $transcriptionAvailableUrl URL to send transcription available events to
      */
-    public function transcriptionAvailableUrl(string $transcriptionAvailableUrl): Record {
+    public function transcriptionAvailableUrl(string $transcriptionAvailableUrl): static {
         $this->transcriptionAvailableUrl = $transcriptionAvailableUrl;
         return $this;
     }
@@ -229,7 +229,7 @@ class Record extends Verb {
      *
      * @param string $transcriptionAvailableMethod HTTP method (GET or POST) to send the transcription available event as
      */
-    public function transcriptionAvailableMethod(string $transcriptionAvailableMethod): Record {
+    public function transcriptionAvailableMethod(string $transcriptionAvailableMethod): static {
         $this->transcriptionAvailableMethod = $transcriptionAvailableMethod;
         return $this;
     }
@@ -239,7 +239,7 @@ class Record extends Verb {
      *
      * @param int $silenceTimeout Number of seconds of silence that ends the recording
      */
-    public function silenceTimeout(int $silenceTimeout): Record {
+    public function silenceTimeout(int $silenceTimeout): static {
         $this->silenceTimeout = $silenceTimeout;
         return $this;
     }
@@ -249,7 +249,7 @@ class Record extends Verb {
      *
      * @param string $recordCompleteFallbackUrl Fallback URL for record complete events 
      */
-    public function recordCompleteFallbackUrl(string $recordCompleteFallbackUrl): Record {
+    public function recordCompleteFallbackUrl(string $recordCompleteFallbackUrl): static {
         $this->recordCompleteFallbackUrl = $recordCompleteFallbackUrl;
         return $this;
     }
@@ -259,7 +259,7 @@ class Record extends Verb {
      *
      * @param string $recordCompleteFallbackMethod HTTP method for fallback events 
      */
-    public function recordCompleteFallbackMethod(string $recordCompleteFallbackMethod): Record {
+    public function recordCompleteFallbackMethod(string $recordCompleteFallbackMethod): static {
         $this->recordCompleteFallbackMethod = $recordCompleteFallbackMethod;
         return $this;
     }
@@ -269,7 +269,7 @@ class Record extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events 
      */
-    public function fallbackUsername(string $fallbackUsername): Record {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -279,7 +279,7 @@ class Record extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events 
      */
-    public function fallbackPassword(string $fallbackPassword): Record {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/Redirect.php
+++ b/src/Voice/Bxml/Redirect.php
@@ -57,7 +57,7 @@ class Redirect extends Verb {
      *
      * @param string $username The username for http authentication on the redirect callback url
      */
-    public function username(string $username): Redirect {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -67,7 +67,7 @@ class Redirect extends Verb {
      *
      * @param string $password The password for http authentication on the redirect callback url
      */
-    public function password(string $password): Redirect {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -77,7 +77,7 @@ class Redirect extends Verb {
      *
      * @param string $redirectUrl The url to receive the redirect callback 
      */
-    public function redirectUrl(string $redirectUrl): Redirect {
+    public function redirectUrl(string $redirectUrl): static {
         $this->redirectUrl = $redirectUrl;
         return $this;
     }
@@ -87,7 +87,7 @@ class Redirect extends Verb {
      *
      * @param string $redirectMethod The http method to send the redirect callback 
      */
-    public function redirectMethod(string $redirectMethod): Redirect {
+    public function redirectMethod(string $redirectMethod): static {
         $this->redirectMethod = $redirectMethod;
         return $this;
     }
@@ -97,7 +97,7 @@ class Redirect extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): Redirect {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -107,7 +107,7 @@ class Redirect extends Verb {
      *
      * @param string $redirectFallbackUrl Fallback url for redirect events 
      */
-    public function redirectFallbackUrl(string $redirectFallbackUrl): Redirect {
+    public function redirectFallbackUrl(string $redirectFallbackUrl): static {
         $this->redirectFallbackUrl = $redirectFallbackUrl;
         return $this;
     }
@@ -117,7 +117,7 @@ class Redirect extends Verb {
      *
      * @param string $redirectFallbackMethod HTTP method for fallback events 
      */
-    public function redirectFallbackMethod(string $redirectFallbackMethod): Redirect {
+    public function redirectFallbackMethod(string $redirectFallbackMethod): static {
         $this->redirectFallbackMethod = $redirectFallbackMethod;
         return $this;
     }
@@ -127,7 +127,7 @@ class Redirect extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events
      */
-    public function fallbackUsername(string $fallbackUsername): Redirect {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -137,7 +137,7 @@ class Redirect extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events 
      */
-    public function fallbackPassword(string $fallbackPassword): Redirect {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/Response.php
+++ b/src/Voice/Bxml/Response.php
@@ -29,7 +29,7 @@ class Response {
      *
      * @param Verb $verb The verb to add to the list
      */
-    public function addVerb(Verb $verb): Response {
+    public function addVerb(Verb $verb): static {
         array_push($this->verbs, $verb);
         return $this;
     }

--- a/src/Voice/Bxml/Ring.php
+++ b/src/Voice/Bxml/Ring.php
@@ -29,7 +29,7 @@ class Ring extends Verb {
      *
      * @param float $duration The duration in seconds for the ring
      */
-    public function duration(float $duration): Ring {
+    public function duration(float $duration): static {
         $this->duration = $duration;
         return $this;
     }
@@ -39,7 +39,7 @@ class Ring extends Verb {
      *
      * @param boolean $answerCall Determines whether or not to answer the call when Ring is executed on an unanswered incoming call
      */
-    public function answerCall(bool $answerCall): Ring {
+    public function answerCall(bool $answerCall): static {
         $this->answerCall = $answerCall;
         return $this;
     }

--- a/src/Voice/Bxml/SendDtmf.php
+++ b/src/Voice/Bxml/SendDtmf.php
@@ -42,7 +42,7 @@ class SendDtmf extends Verb {
      *
      * @param double $toneDuration The length in milliseconds of each DTMF tone
      */
-    public function toneDuration(float $toneDuration): SendDtmf {
+    public function toneDuration(float $toneDuration): static {
         $this->toneDuration = $toneDuration;
         return $this;
     }
@@ -52,7 +52,7 @@ class SendDtmf extends Verb {
      *
      * @param double $toneInterval The duration of silence in milliseconds following each DTMF tone
      */
-    public function toneInterval(float $toneInterval): SendDtmf {
+    public function toneInterval(float $toneInterval): static {
         $this->toneInterval = $toneInterval;
         return $this;
     }

--- a/src/Voice/Bxml/SipUri.php
+++ b/src/Voice/Bxml/SipUri.php
@@ -82,7 +82,7 @@ class SipUri extends Verb {
      *
      * @param string $username The username for http authentication on the audio url
      */
-    public function username(string $username): SipUri {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -92,7 +92,7 @@ class SipUri extends Verb {
      *
      * @param string $password The password for http authentication on the audio url
      */
-    public function password(string $password): SipUri {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -102,7 +102,7 @@ class SipUri extends Verb {
      *
      * @param string $transferAnswerUrl The url to receive the transfer answered callback 
      */
-    public function transferAnswerUrl(string $transferAnswerUrl): SipUri {
+    public function transferAnswerUrl(string $transferAnswerUrl): static {
         $this->transferAnswerUrl = $transferAnswerUrl;
         return $this;
     }
@@ -112,7 +112,7 @@ class SipUri extends Verb {
      *
      * @param string $transferAnswerMethod The http method to send the transfer answered callback 
      */
-    public function transferAnswerMethod(string $transferAnswerMethod): SipUri {
+    public function transferAnswerMethod(string $transferAnswerMethod): static {
         $this->transferAnswerMethod = $transferAnswerMethod;
         return $this;
     }
@@ -122,7 +122,7 @@ class SipUri extends Verb {
      *
      * @param string $transferDisconnectUrl The url to receive the transfer disconnect callback 
      */
-    public function transferDisconnectUrl(string $transferDisconnectUrl): SipUri {
+    public function transferDisconnectUrl(string $transferDisconnectUrl): static {
         $this->transferDisconnectUrl = $transferDisconnectUrl;
         return $this;
     }
@@ -132,7 +132,7 @@ class SipUri extends Verb {
      *
      * @param string $transferDisconnectMethod The http method to send the transfer disconnect callback 
      */
-    public function transferDisconnectMethod(string $transferDisconnectMethod): SipUri {
+    public function transferDisconnectMethod(string $transferDisconnectMethod): static {
         $this->transferDisconnectMethod = $transferDisconnectMethod;
         return $this;
     }
@@ -142,7 +142,7 @@ class SipUri extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): SipUri {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -152,7 +152,7 @@ class SipUri extends Verb {
      *
      * @param string $uui The value of the `User-To-User` header to send within the initial `INVITE`
      */
-    public function uui(string $uui): SipUri {
+    public function uui(string $uui): static {
         $this->uui = $uui;
         return $this;
     }
@@ -162,7 +162,7 @@ class SipUri extends Verb {
      *
      * @param string $transferAnswerFallbackUrl Fallback URL for transfer answer events 
      */
-    public function transferAnswerFallbackUrl(string $transferAnswerFallbackUrl): SipUri {
+    public function transferAnswerFallbackUrl(string $transferAnswerFallbackUrl): static {
         $this->transferAnswerFallbackUrl = $transferAnswerFallbackUrl;
         return $this;
     }
@@ -172,7 +172,7 @@ class SipUri extends Verb {
      *
      * @param string $transferAnswerFallbackMethod HTTP method for fallback events 
      */
-    public function transferAnswerFallbackMethod(string $transferAnswerFallbackMethod): SipUri {
+    public function transferAnswerFallbackMethod(string $transferAnswerFallbackMethod): static {
         $this->transferAnswerFallbackMethod = $transferAnswerFallbackMethod;
         return $this;
     }
@@ -182,7 +182,7 @@ class SipUri extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events 
      */
-    public function fallbackUsername(string $fallbackUsername): SipUri {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -192,7 +192,7 @@ class SipUri extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events
      */
-    public function fallbackPassword(string $fallbackPassword): SipUri {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }

--- a/src/Voice/Bxml/SpeakSentence.php
+++ b/src/Voice/Bxml/SpeakSentence.php
@@ -46,7 +46,7 @@ class SpeakSentence extends Verb {
      *
      * @param string $voice The voice to speak in the call
      */
-    public function voice(string $voice): SpeakSentence {
+    public function voice(string $voice): static {
         $this->voice = $voice;
         return $this;
     }
@@ -56,7 +56,7 @@ class SpeakSentence extends Verb {
      *
      * @param string $locale The locale of the voice in the call
      */
-    public function locale(string $locale): SpeakSentence {
+    public function locale(string $locale): static {
         $this->locale = $locale;
         return $this;
     }
@@ -66,7 +66,7 @@ class SpeakSentence extends Verb {
      *
      * @param string $gender The gender of the voice in the call
      */
-    public function gender(string $gender): SpeakSentence {
+    public function gender(string $gender): static {
         $this->gender = $gender;
         return $this;
     }

--- a/src/Voice/Bxml/StartGather.php
+++ b/src/Voice/Bxml/StartGather.php
@@ -43,7 +43,7 @@ class StartGather extends Verb {
      *
      * @param string $username The username for http authentication for the gather callback
      */
-    public function username(string $username): StartGather {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -53,7 +53,7 @@ class StartGather extends Verb {
      *
      * @param string $password The password for http authentication for the gather callback
      */
-    public function password(string $password): StartGather {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -63,7 +63,7 @@ class StartGather extends Verb {
      *
      * @param string $dtmfUrl The url to receive the dtmf callback 
      */
-    public function dtmfUrl(string $dtmfUrl): StartGather {
+    public function dtmfUrl(string $dtmfUrl): static {
         $this->dtmfUrl = $dtmfUrl;
         return $this;
     }
@@ -73,7 +73,7 @@ class StartGather extends Verb {
      *
      * @param string $dtmfMethod The http method to send the dtmf callback 
      */
-    public function dtmfMethod(string $dtmfMethod): StartGather {
+    public function dtmfMethod(string $dtmfMethod): static {
         $this->dtmfMethod = $dtmfMethod;
         return $this;
     }
@@ -83,7 +83,7 @@ class StartGather extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): StartGather {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }

--- a/src/Voice/Bxml/StartRecording.php
+++ b/src/Voice/Bxml/StartRecording.php
@@ -65,7 +65,7 @@ class StartRecording extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): StartRecording {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -75,7 +75,7 @@ class StartRecording extends Verb {
      *
      * @param string $recordingAvailableUrl URL to send the record available callback to
      */
-    public function recordingAvailableUrl(string $recordingAvailableUrl): StartRecording {
+    public function recordingAvailableUrl(string $recordingAvailableUrl): static {
         $this->recordingAvailableUrl = $recordingAvailableUrl;
         return $this;
     }
@@ -86,7 +86,7 @@ class StartRecording extends Verb {
      * @param string $recordingAvailableMethod HTTP method to send record available
      * as ("GET" or "POST")
      */
-    public function recordingAvailableMethod(string $recordingAvailableMethod): StartRecording {
+    public function recordingAvailableMethod(string $recordingAvailableMethod): static {
         $this->recordingAvailableMethod = $recordingAvailableMethod;
         return $this;
     }
@@ -96,7 +96,7 @@ class StartRecording extends Verb {
      *
      * @param string $username Username for basic auth for callbacks
      */
-    public function username(string $username): StartRecording {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -106,7 +106,7 @@ class StartRecording extends Verb {
      *
      * @param string $password Password for basic auth for callbacks
      */
-    public function password(string $password): StartRecording {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -116,7 +116,7 @@ class StartRecording extends Verb {
      *
      * @param string $fileFormat Audio format of the recording ("mp3" or "wav")
      */
-    public function fileFormat(string $fileFormat): StartRecording {
+    public function fileFormat(string $fileFormat): static {
         $this->fileFormat = $fileFormat;
         return $this;
     }
@@ -126,7 +126,7 @@ class StartRecording extends Verb {
      *
      * @param boolean $detectLanguage Indicates that the recording may not be in English, and the transcription service will need to detect the dominant language the recording is in and transcribe accordingly. Current supported languages are English, French, and Spanish.
      */
-    public function detectLanguage($detectLanguage): StartRecording {
+    public function detectLanguage($detectLanguage): static {
         $this->detectLanguage = $detectLanguage;
         return $this;
     }
@@ -137,7 +137,7 @@ class StartRecording extends Verb {
      *
      * @param bool $multiChannel True to record the audio as 2 channels, false otherwise
      */
-    public function multiChannel(bool $multiChannel): StartRecording {
+    public function multiChannel(bool $multiChannel): static {
         $this->multiChannel = $multiChannel;
         return $this;
     }
@@ -147,7 +147,7 @@ class StartRecording extends Verb {
      *
      * @param boolean $transcribe True to submit the recording for transcription, false otherwise
      */
-    public function transcribe(bool $transcribe): StartRecording {
+    public function transcribe(bool $transcribe): static {
         $this->transcribe = $transcribe;
         return $this;
     }
@@ -157,7 +157,7 @@ class StartRecording extends Verb {
      *
      * @param string $transcriptionAvailableUrl URL to send transcription available events to
      */
-    public function transcriptionAvailableUrl(string $transcriptionAvailableUrl): StartRecording {
+    public function transcriptionAvailableUrl(string $transcriptionAvailableUrl): static {
         $this->transcriptionAvailableUrl = $transcriptionAvailableUrl;
         return $this;
     }
@@ -167,7 +167,7 @@ class StartRecording extends Verb {
      *
      * @param string $transcriptionAvailableMethod HTTP method (GET or POST) to send the transcription available event as
      */
-    public function transcriptionAvailableMethod(string $transcriptionAvailableMethod): StartRecording {
+    public function transcriptionAvailableMethod(string $transcriptionAvailableMethod): static {
         $this->transcriptionAvailableMethod = $transcriptionAvailableMethod;
         return $this;
     }

--- a/src/Voice/Bxml/StartStream.php
+++ b/src/Voice/Bxml/StartStream.php
@@ -50,7 +50,7 @@ class StartStream extends Verb {
      *
      * @param string $destination A websocket URI to send the stream to. The audio from the specified tracks will be sent via websocket to this URL encoded as base64 encoded PCMU/G711 audio. See below for more details on the websocket packet format.
      */
-    public function destination(string $destination): StartStream {
+    public function destination(string $destination): static {
         $this->destination = $destination;
         return $this;
     }
@@ -60,7 +60,7 @@ class StartStream extends Verb {
      *
      * @param string $name A name to refer to this stream by. Used when sending [`<StopStream>`][1]. If not provided, a random name will be generated and sent in the [`Media Stream Started`][2] webook
      */
-    public function name(string $name): StartStream {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }
@@ -71,7 +71,7 @@ class StartStream extends Verb {
      * @param string $tracks The part of the call to send a stream from. `inbound`, `outbound` or `both`. Default is `inbound`. 
      * 
      */
-    public function tracks(string $tracks): StartStream {
+    public function tracks(string $tracks): static {
         $this->tracks = $tracks;
         return $this;
     }
@@ -81,7 +81,7 @@ class StartStream extends Verb {
      *
      * @param string $username The username to send in the HTTP request to `streamEventUrl`. If specified, the URLs must be TLS-encrypted (i.e., `https`). 
      */
-    public function username(string $username): StartStream {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -91,7 +91,7 @@ class StartStream extends Verb {
      *
      * @param string $password The password to send in the HTTP request to `streamEventUrl`. If specified, the URLs must be TLS-encrypted (i.e., `https`).    
      */
-    public function password(string $password): StartStream {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -101,7 +101,7 @@ class StartStream extends Verb {
      *
      * @param string $streamEventUrl URL to send the associated Webhook events to during this stream's lifetime. Does not accept BXML. May be a relative URL. 
      */
-    public function streamEventUrl(string $streamEventUrl): StartStream {
+    public function streamEventUrl(string $streamEventUrl): static {
         $this->streamEventUrl = $streamEventUrl;
         return $this;
     }
@@ -111,7 +111,7 @@ class StartStream extends Verb {
      *
      * @param bool $streamEventMethod The HTTP method to use for the request to `streamEventUrl`. GET or POST. Default value is POST. 
      */
-    public function streamEventMethod(string $streamEventMethod): StartStream {
+    public function streamEventMethod(string $streamEventMethod): static {
         $this->streamEventMethod = $streamEventMethod;
         return $this;
     }
@@ -121,7 +121,7 @@ class StartStream extends Verb {
      *
      * @param list<StreamParam> $streamParams The list of StreamParam tags
      */
-    public function streamParams($streamParams): StartStream {
+    public function streamParams($streamParams): static {
         $this->streamParams = $streamParams;
         return $this;
     }

--- a/src/Voice/Bxml/StartTranscription.php
+++ b/src/Voice/Bxml/StartTranscription.php
@@ -54,7 +54,7 @@ class StartTranscription extends Verb {
      *
      * @param string $destination A websocket URI to send the real-time transcription to. The audio from the specified tracks will be sent via websocket to this URL encoded as base64 encoded PCMU/G711 audio. See below for more details on the websocket packet format.
      */
-    public function destination(string $destination): StartTranscription {
+    public function destination(string $destination): static {
         $this->destination = $destination;
         return $this;
     }
@@ -64,7 +64,7 @@ class StartTranscription extends Verb {
      *
      * @param string $name A name to refer to this transcription by. Used when sending <StopTranscription>. If not provided, it will default to the generated transcription id as sent in the real-time Transcription Started webhook.
      */
-    public function name(string $name): StartTranscription {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }
@@ -75,7 +75,7 @@ class StartTranscription extends Verb {
      * @param string $tracks The part of the call to send a real-time transcription from. `inbound`, `outbound` or `both`. Default is `inbound`. 
      * 
      */
-    public function tracks(string $tracks): StartTranscription {
+    public function tracks(string $tracks): static {
         $this->tracks = $tracks;
         return $this;
     }
@@ -85,7 +85,7 @@ class StartTranscription extends Verb {
      *
      * @param string $username The username to send in the HTTP request to `transcriptionEventUrl`. If specified, the URLs must be TLS-encrypted (i.e., `https`). 
      */
-    public function username(string $username): StartTranscription {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -95,7 +95,7 @@ class StartTranscription extends Verb {
      *
      * @param string $password The password to send in the HTTP request to `transcriptionEventUrl`. If specified, the URLs must be TLS-encrypted (i.e., `https`).    
      */
-    public function password(string $password): StartTranscription {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -105,7 +105,7 @@ class StartTranscription extends Verb {
      *
      * @param string $transcriptionEventUrl URL to send the associated Webhook events to during this stream's lifetime. Does not accept BXML. May be a relative URL. 
      */
-    public function transcriptionEventUrl(string $transcriptionEventUrl): StartTranscription {
+    public function transcriptionEventUrl(string $transcriptionEventUrl): static {
         $this->transcriptionEventUrl = $transcriptionEventUrl;
         return $this;
     }
@@ -115,7 +115,7 @@ class StartTranscription extends Verb {
      *
      * @param bool $transcriptionEventMethod The HTTP method to use for the request to `transcriptionEventUrl`. GET or POST. Default value is POST. 
      */
-    public function transcriptionEventMethod(string $transcriptionEventMethod): StartTranscription {
+    public function transcriptionEventMethod(string $transcriptionEventMethod): static {
         $this->transcriptionEventMethod = $transcriptionEventMethod;
         return $this;
     }
@@ -126,7 +126,7 @@ class StartTranscription extends Verb {
      * @param bool Whether to send transcription update events to the specified destination only after they have become stable. Requires destination. Defaults to true.
      * 
      */
-    public function stability( bool $stability): StartTranscription {
+    public function stability( bool $stability): static {
         $this->stability = $stability;
         return $this;
     }
@@ -136,7 +136,7 @@ class StartTranscription extends Verb {
      *
      * @param list<CustomParam> $customParams The list of CustomParam tags
      */
-    public function customParams($customParams): StartTranscription {
+    public function customParams($customParams): static {
         $this->customParams = $customParams;
         return $this;
     }

--- a/src/Voice/Bxml/StopStream.php
+++ b/src/Voice/Bxml/StopStream.php
@@ -25,7 +25,7 @@ class StopStream extends Verb {
      *
      * @param string $name (required) The name of the stream to stop. This is either the user selected name when sending the [`<StartStream>`][1] verb, or the system generated name returned in the [Media Stream Started][2] webhook if `<StartStream>` was sent with no `name` attribute.
      */
-    public function name(string $name): StopStream {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }

--- a/src/Voice/Bxml/StopTranscription.php
+++ b/src/Voice/Bxml/StopTranscription.php
@@ -25,7 +25,7 @@ class StopTranscription extends Verb {
      *
      * @param string $name (required) The name of the real-time transcription to stop. This is either the user selected name when sending the [`<StartTranscription>`][1] verb, or the system generated name returned in the [Media Transcription Started][2] webhook if `<StartTranscription>` was sent with no `name` attribute.
      */
-    public function name(string $name): StopTranscription {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }

--- a/src/Voice/Bxml/StreamParam.php
+++ b/src/Voice/Bxml/StreamParam.php
@@ -29,7 +29,7 @@ class StreamParam extends Verb {
      *
      * @param string $name (required) The name of this parameter, up to 256 characters.
      */
-    public function name(string $name): StreamParam {
+    public function name(string $name): static {
         $this->name = $name;
         return $this;
     }
@@ -39,7 +39,7 @@ class StreamParam extends Verb {
      *
      * @param string $value (required) The value of this parameter, up to 2048 characters.
      */
-    public function value(string $value): StreamParam {
+    public function value(string $value): static {
         $this->value = $value;
         return $this;
     }

--- a/src/Voice/Bxml/Transfer.php
+++ b/src/Voice/Bxml/Transfer.php
@@ -79,7 +79,7 @@ class Transfer extends Verb {
      *
      * @param string $username The username for http authentication on the transfer answered callback url
      */
-    public function username(string $username): Transfer {
+    public function username(string $username): static {
         $this->username = $username;
         return $this;
     }
@@ -89,7 +89,7 @@ class Transfer extends Verb {
      *
      * @param string $password The password for http authentication on the transfer answered callback url
      */
-    public function password(string $password): Transfer {
+    public function password(string $password): static {
         $this->password = $password;
         return $this;
     }
@@ -99,7 +99,7 @@ class Transfer extends Verb {
      *
      * @param string $transferCompleteUrl The url to receive the transfer answered callback 
      */
-    public function transferCompleteUrl(string $transferCompleteUrl): Transfer {
+    public function transferCompleteUrl(string $transferCompleteUrl): static {
         $this->transferCompleteUrl = $transferCompleteUrl;
         return $this;
     }
@@ -109,7 +109,7 @@ class Transfer extends Verb {
      *
      * @param string $transferCompleteMethod The http method to send the transfer answered callback 
      */
-    public function transferCompleteMethod(string $transferCompleteMethod): Transfer {
+    public function transferCompleteMethod(string $transferCompleteMethod): static {
         $this->transferCompleteMethod = $transferCompleteMethod;
         return $this;
     }
@@ -119,7 +119,7 @@ class Transfer extends Verb {
      *
      * @param string $transferCallerId The caller id to use when the call is transferred
      */
-    public function transferCallerId(string $transferCallerId): Transfer {
+    public function transferCallerId(string $transferCallerId): static {
         $this->transferCallerId = $transferCallerId;
         return $this;
     }
@@ -127,7 +127,7 @@ class Transfer extends Verb {
     /**
      * Sets the transferCallerDisplayName attribute for Transfer
      */
-    public function transferCallerDisplayName(string $transferCallerDisplayName): Transfer {
+    public function transferCallerDisplayName(string $transferCallerDisplayName): static {
         $this->transferCallerDisplayName = $transferCallerDisplayName;
         return $this;
     }
@@ -137,7 +137,7 @@ class Transfer extends Verb {
      *
      * @param int $callTimeout The number of seconds to wait before timing out the call
      */
-    public function callTimeout(int $callTimeout): Transfer {
+    public function callTimeout(int $callTimeout): static {
         $this->callTimeout = $callTimeout;
         return $this;
     }
@@ -147,7 +147,7 @@ class Transfer extends Verb {
      *
      * @param string $tag A custom string to be included in callbacks 
      */
-    public function tag(string $tag): Transfer {
+    public function tag(string $tag): static {
         $this->tag = $tag;
         return $this;
     }
@@ -157,7 +157,7 @@ class Transfer extends Verb {
      *
      * @param string $diversionTreatment The diversion treatment for the phone call 
      */
-    public function diversionTreatment(string $diversionTreatment): Transfer {
+    public function diversionTreatment(string $diversionTreatment): static {
         $this->diversionTreatment = $diversionTreatment;
         return $this;
     }
@@ -167,7 +167,7 @@ class Transfer extends Verb {
      *
      * @param string $diversionReason The diversion treatment for the phone call 
      */
-    public function diversionReason(string $diversionReason): Transfer {
+    public function diversionReason(string $diversionReason): static {
         $this->diversionReason = $diversionReason;
         return $this;
     }
@@ -177,7 +177,7 @@ class Transfer extends Verb {
      *
      * @param list<PhoneNumber> $phoneNumbers The list of PhoneNumber tags
      */
-    public function phoneNumbers($phoneNumbers): Transfer {
+    public function phoneNumbers($phoneNumbers): static {
         $this->phoneNumbers = $phoneNumbers;
         return $this;
     }
@@ -187,7 +187,7 @@ class Transfer extends Verb {
      *
      * @param list<SipUri> $sipUris The list of SipUri tags
      */
-    public function sipUris($sipUris): Transfer {
+    public function sipUris($sipUris): static {
         $this->sipUris = $sipUris;
         return $this;
     }
@@ -197,7 +197,7 @@ class Transfer extends Verb {
      *
      * @param string $transferCompleteFallbackUrl Fallback url for transfer complete events 
      */
-    public function transferCompleteFallbackUrl(string $transferCompleteFallbackUrl): Transfer {
+    public function transferCompleteFallbackUrl(string $transferCompleteFallbackUrl): static {
         $this->transferCompleteFallbackUrl = $transferCompleteFallbackUrl;
         return $this;
     }
@@ -207,7 +207,7 @@ class Transfer extends Verb {
      *
      * @param string $transferCompleteFallbackMethod HTTP method for fallback events
      */
-    public function transferCompleteFallbackMethod(string $transferCompleteFallbackMethod): Transfer {
+    public function transferCompleteFallbackMethod(string $transferCompleteFallbackMethod): static {
         $this->transferCompleteFallbackMethod = $transferCompleteFallbackMethod;
         return $this;
     }
@@ -217,7 +217,7 @@ class Transfer extends Verb {
      *
      * @param string $fallbackUsername HTTP basic auth username for fallback events 
      */
-    public function fallbackUsername(string $fallbackUsername): Transfer {
+    public function fallbackUsername(string $fallbackUsername): static {
         $this->fallbackUsername = $fallbackUsername;
         return $this;
     }
@@ -227,7 +227,7 @@ class Transfer extends Verb {
      *
      * @param string $fallbackPassword HTTP basic auth password for fallback events
      */
-    public function fallbackPassword(string $fallbackPassword): Transfer {
+    public function fallbackPassword(string $fallbackPassword): static {
         $this->fallbackPassword = $fallbackPassword;
         return $this;
     }


### PR DESCRIPTION
Linting exposed that these methods should really return `static` instead of the class type in case they are extended for some reason.