### PR TITLE
SWI-9298 PHP Implicitly nullable parameter declarations deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022, windows-2025, ubuntu-22.04, ubuntu-24.04]
-        php-version: [8.0, 8.1, 8.2, 8.3]
+        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
     steps:
     - name: Checkout
       uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "ext-SimpleXML": "*",
-        "php": ">=8.4.0",
+        "php": ">=8.0.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "ext-SimpleXML": "*",
-        "php": ">=7.2.0",
+        "php": ">=8.4.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/APIException.php
+++ b/src/APIException.php
@@ -35,9 +35,10 @@ class APIException extends \Exception
         $this->context = $context;
         $this->errorMessage = $reason;
 
-        if (get_class() != 'APIException') {
+        if (static::class !== 'BandwidthLib\APIException') {
             $this->unbox();
         }
+
     }
 
     /**

--- a/src/Http/HttpCallBack.php
+++ b/src/Http/HttpCallBack.php
@@ -29,7 +29,7 @@ class HttpCallBack
      * @param callable|null $onBeforeRequest Called before an API call
      * @param callable|null $onAfterRequest  Called after an API call
      */
-    public function __construct(callable $onBeforeRequest = null, callable $onAfterRequest = null)
+    public function __construct(?callable $onBeforeRequest = null, ?callable $onAfterRequest = null)
     {
         $this->onBeforeRequest = $onBeforeRequest;
         $this->onAfterRequest = $onAfterRequest;

--- a/src/Http/HttpRequest.php
+++ b/src/Http/HttpRequest.php
@@ -43,7 +43,7 @@ class HttpRequest
      * @param string|null $queryUrl   Query url
      * @param array|null $parameters Map of parameters sent
      */
-    public function __construct(string $httpMethod = null, array $headers = null, string $queryUrl = null, array $parameters = null)
+    public function __construct(?string $httpMethod = null, ?array $headers = null, ?string $queryUrl = null, ?array $parameters = null)
     {
         $this->httpMethod = $httpMethod;
         $this->headers = $headers;

--- a/src/Messaging/Controllers/APIController.php
+++ b/src/Messaging/Controllers/APIController.php
@@ -40,7 +40,7 @@ class APIController extends BaseController
      */
     public function listMedia(
         string $accountId,
-        string $continuationToken = null
+        ?string $continuationToken = null
     ) {
 
         //prepare query string for API call
@@ -225,7 +225,7 @@ class APIController extends BaseController
         string $mediaId,
         string $body,
         string $contentType = 'application/octet-stream',
-        string $cacheControl = null
+        ?string $cacheControl = null
     ) {
 
         //prepare query string for API call
@@ -418,16 +418,16 @@ class APIController extends BaseController
      * @throws APIException Thrown if API call fails
      */
     public function getMessages(
-        string $accountId,
-        string $messageId = null,
-        string $sourceTn = null,
-        string $destinationTn = null,
-        string $messageStatus = null,
-        int    $errorCode = null,
-        string $fromDateTime = null,
-        string $toDateTime = null,
-        string $pageToken = null,
-        int    $limit = null
+        string  $accountId,
+        ?string $messageId = null,
+        ?string $sourceTn = null,
+        ?string $destinationTn = null,
+        ?string $messageStatus = null,
+        ?int    $errorCode = null,
+        ?string $fromDateTime = null,
+        ?string $toDateTime = null,
+        ?string $pageToken = null,
+        ?int    $limit = null
     ) {
 
         //prepare query string for API call

--- a/src/Voice/Controllers/APIController.php
+++ b/src/Voice/Controllers/APIController.php
@@ -1492,12 +1492,12 @@ class APIController extends BaseController
      * @throws APIException Thrown if API call fails
      */
     public function getConferences(
-        string $accountId,
-        string $name = null,
-        string $minCreatedTime = null,
-        string $maxCreatedTime = null,
-        int    $pageSize = 1000,
-        string $pageToken = null
+        string  $accountId,
+        ?string $name = null,
+        ?string $minCreatedTime = null,
+        ?string $maxCreatedTime = null,
+        int     $pageSize = 1000,
+        ?string $pageToken = null
     ) {
 
         //prepare query string for API call
@@ -2403,11 +2403,11 @@ class APIController extends BaseController
      * @throws APIException Thrown if API call fails
      */
     public function getQueryCallRecordings(
-        string $accountId,
-        string $from = null,
-        string $to = null,
-        string $minStartTime = null,
-        string $maxStartTime = null
+        string  $accountId,
+        ?string $from = null,
+        ?string $to = null,
+        ?string $minStartTime = null,
+        ?string $maxStartTime = null
     ) {
 
         //prepare query string for API call

--- a/src/WebRtc/Controllers/APIController.php
+++ b/src/WebRtc/Controllers/APIController.php
@@ -43,7 +43,7 @@ class APIController extends BaseController
      */
     public function createParticipant(
         string             $accountId,
-        Models\Participant $body = null
+        ?Models\Participant $body = null
     ) {
 
         //prepare query string for API call
@@ -283,7 +283,7 @@ class APIController extends BaseController
      */
     public function createSession(
         string         $accountId,
-        Models\Session $body = null
+        ?Models\Session $body = null
     ) {
 
         //prepare query string for API call
@@ -602,7 +602,7 @@ class APIController extends BaseController
         string               $accountId,
         string               $sessionId,
         string               $participantId,
-        Models\Subscriptions $body = null
+        ?Models\Subscriptions $body = null
     ) {
 
         //prepare query string for API call
@@ -854,7 +854,7 @@ class APIController extends BaseController
         string               $accountId,
         string               $sessionId,
         string               $participantId,
-        Models\Subscriptions $body = null
+        ?Models\Subscriptions $body = null
     ) {
 
         //prepare query string for API call


### PR DESCRIPTION
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types