### PR TITLE
SWI-11188: fix Backstage conflicting entityRef by inlining component into catalog-info.yaml

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,11 +1,15 @@
 apiVersion: backstage.io/v1alpha1
-kind: Location
+kind: Component
 metadata:
   schemaVersion: v1.0.0
-  name: php-sdk-location
-  description: Links to additional entities in the php-sdk repository.
+  name: php-sdk
+  description: Bandwidth PHP SDK
   annotations:
     github.com/project-slug: Bandwidth/php-sdk
+  organization: BW
+  costCenter: Development - Software Infra
+  buildPlatform: GitHub Actions
 spec:
-  targets:
-    - ./component.yaml
+  type: Library
+  owner: github/band-swi
+  lifecycle: Available


### PR DESCRIPTION
## Summary

- Replace `.bandwidth/catalog-info.yaml` (currently `kind: Location` pointing to `./component.yaml`) with the component definition inlined directly as `kind: Component`
- The two-file pattern (`kind: Location` → separate `component.yaml`) causes Backstage to produce recurring "conflicting entityRef" warnings in Datadog every 30 minutes, because the named location entity collides with the generated location that mainBranchProvider already registered for this file
- The single-file pattern is the current Backstage standard; the `.bandwidth/component.yaml` file is no longer needed by Backstage after this change

Tracked in [SWI-11188](https://bandwidth.atlassian.net/browse/SWI-11188).

[SWI-11188]: https://bandwidth-jira.atlassian.net/browse/SWI-11188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ